### PR TITLE
Conduit 0.3 fix

### DIFF
--- a/VerDB.hs
+++ b/VerDB.hs
@@ -35,15 +35,14 @@ getVerAlist installedOnly = justOnly <$> verInfos
     verInfos = runResourceT $ sourceCmd script $$ cabalListParser
     justOnly = map (second fromJust) . filter (isJust . snd)
 
+    cabalListParser = sinkParser verinfos
+
 ----------------------------------------------------------------
 
 lookupLatestVersion :: String -> VerDB -> Maybe [Int]
 lookupLatestVersion pkgid (VerDB db) = M.lookup pkgid db
 
 ----------------------------------------------------------------
-
-cabalListParser :: Sink ByteString IO [VerInfo]
-cabalListParser = sinkParser verinfos
 
 verinfos :: Parser [VerInfo]
 verinfos = many1 verinfo


### PR DESCRIPTION
the type of `sinkParser` from `attoparsec-conduit-0.3` was changed, 
remove it from top-level to hide type declaration.
