### PR TITLE
Add GHCi option.

### DIFF
--- a/CmdDB.hs
+++ b/CmdDB.hs
@@ -205,6 +205,14 @@ commandDB = [
        , manual = Nothing
        }
   , CommandSpec {
+         command = Ghci
+       , commandNames = ["ghci"]
+       , document = "Run GHCi within a sandbox"
+       , routing = RouteFunc ghci
+       , switches = [(SwSandbox, Just "--sandbox")]
+       , manual = Nothing
+       }
+  , CommandSpec {
          command = Help
        , commandNames = ["help"]
        , document = "Display the help message of the command"

--- a/Commands.hs
+++ b/Commands.hs
@@ -1,6 +1,6 @@
 module Commands (
     deps, revdeps, installed, outdated, uninstall, search, env
-  , genpaths, check, add
+  , genpaths, check, add, ghci
   ) where
 
 import Control.Applicative hiding (many)
@@ -194,3 +194,12 @@ add _ params opts = case getSandbox opts of
             system $ "cabal-dev add-source " ++ src ++ " -s " ++ sbox
             return ()
         _ -> hPutStrLn stderr "A source path be specified."
+
+----------------------------------------------------------------
+
+ghci :: FunctionCommand
+ghci _ _ opts = case getSandbox opts of
+    Nothing -> hPutStrLn stderr "A sandbox must be specified with \"-s\" option."
+    Just sbox -> do
+      system $ "cabal-dev -s " ++ sbox ++ " ghci"
+      return ()

--- a/Types.hs
+++ b/Types.hs
@@ -80,6 +80,7 @@ data Command = Sync
              | Search
              | Env
              | Add
+             | Ghci
              | Test
              | Doc
              | Help


### PR DESCRIPTION
You may not want this but just thought it was really easy to do, so feel free to ignore it!

Loads up ghci with sandbox, useful when using CAB_SANDBOX_PATH.
Simply a wrapper to cabal-dev.
