### PR TITLE
Allow specifying a custom package database with --package-db

### DIFF
--- a/Distribution/Cab/Sandbox.hs
+++ b/Distribution/Cab/Sandbox.hs
@@ -26,8 +26,9 @@ pkgDbKeyLen = length pkgDbKey
 
 -- | Find a sandbox config file by tracing ancestor directories,
 --   parse it and return the package db path
-getSandbox :: IO (Maybe FilePath)
-getSandbox = (Just <$> getPkgDb) `E.catch` handler
+getSandbox :: Maybe FilePath -> IO (Maybe FilePath)
+getSandbox j@(Just _) = return j
+getSandbox Nothing    = (Just <$> getPkgDb) `E.catch` handler
   where
     getPkgDb = getCurrentDirectory >>= getSandboxConfigFile >>= getPackageDbDir
     handler :: SomeException -> IO (Maybe String)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -33,7 +33,8 @@ main = flip E.catches handlers $ do
         mcmdspec = commandSpecByName act (commandDB helpCommandAndExit)
     when (isNothing mcmdspec) (illegalCommandAndExit act)
     let Just cmdspec = mcmdspec
-    checkOptions2 opts1 cmdspec oargs illegalOptionsAndExit
+-- TODO
+--    checkOptions2 opts1 cmdspec oargs illegalOptionsAndExit
     run cmdspec params opts1
   where
     handlers = [Handler handleExit]

--- a/src/Options.hs
+++ b/src/Options.hs
@@ -51,6 +51,9 @@ getOptDB = [
   , Option ['h'] ["help"]
       (NoArg OptHelp)
       "Show help message"
+  , Option [] ["package-db"]
+      (ReqArg OptPackageDB "<path.conf.d>")
+      "Use a custom package db"
   ]
 
 optionDB :: OptionDB

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -10,20 +10,21 @@ import Types
 ----------------------------------------------------------------
 
 toSwitch :: Option -> Switch
-toSwitch OptNoharm      = SwNoharm
-toSwitch OptRecursive   = SwRecursive
-toSwitch OptAll         = SwAll
-toSwitch OptInfo        = SwInfo
-toSwitch (OptFlag _)    = SwFlag
-toSwitch OptTest        = SwTest
-toSwitch OptBench       = SwBench
-toSwitch OptDepsOnly    = SwDepsOnly
-toSwitch OptLibProfile  = SwLibProfile
-toSwitch OptExecProfile = SwExecProfile
-toSwitch (OptJobs _)    = SwJobs
-toSwitch (OptImport _)  = SwImport
-toSwitch OptStatic      = SwStatic
-toSwitch _              = error "toSwitch"
+toSwitch OptNoharm        = SwNoharm
+toSwitch OptRecursive     = SwRecursive
+toSwitch OptAll           = SwAll
+toSwitch OptInfo          = SwInfo
+toSwitch (OptFlag _)      = SwFlag
+toSwitch OptTest          = SwTest
+toSwitch OptBench         = SwBench
+toSwitch OptDepsOnly      = SwDepsOnly
+toSwitch OptLibProfile    = SwLibProfile
+toSwitch OptExecProfile   = SwExecProfile
+toSwitch (OptJobs _)      = SwJobs
+toSwitch (OptImport _)    = SwImport
+toSwitch OptStatic        = SwStatic
+toSwitch (OptPackageDB _) = SwPackageDB
+toSwitch _                = error "toSwitch"
 
 ----------------------------------------------------------------
 

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -22,6 +22,7 @@ data Switch = SwNoharm
             | SwJobs
             | SwImport
             | SwStatic
+            | SwPackageDB
             deriving (Eq,Show)
 
 ----------------------------------------------------------------


### PR DESCRIPTION
**This isn't completely finished**

This adds a `--package-db` flag so you can run cab from anywhere and also lets you use it with cabal-dev.
You can run e.g. `cab outdated --package-db=-package-db=/foo/bar/cabal-dev/packages-7.8.2.conf`.

Are you okay with adding this feature?

I didn't quite understand what to do about the switches, i tried blindly adding it as seemed appropriate (not in this commit) but didn't get it working, I'd appreciate some help here! I temporarily commented out the `checkOptions2` to test the rest.
