### PR TITLE
Replace deprecated sourceCmd with sourceCmdWithConsumer

### DIFF
--- a/Distribution/Cab/VerDB.hs
+++ b/Distribution/Cab/VerDB.hs
@@ -16,7 +16,6 @@ import Control.Applicative
 import Control.Arrow (second)
 import Control.Monad.Trans.Resource (runResourceT)
 import Data.Attoparsec.ByteString.Char8
-import Data.Conduit
 import Data.Conduit.Attoparsec
 import Data.Conduit.Process
 import Data.Map (Map)
@@ -42,8 +41,8 @@ getVerDB how = VerDB . justOnly <$> verInfos
     script = case how of
         InstalledOnly -> "cabal list --installed"
         AllRegistered -> "cabal list"
-    verInfos = runResourceT $ sourceCmd script $$ cabalListParser
-    justOnly = map (second (toVer . fromJust)) . filter (isJust . snd)
+    verInfos = runResourceT $ sourceCmdWithConsumer script cabalListParser
+    justOnly = map (second (toVer . fromJust)) . filter (isJust . snd) . snd
     cabalListParser = sinkParser verinfos
 
 ----------------------------------------------------------------

--- a/cab.cabal
+++ b/cab.cabal
@@ -1,5 +1,5 @@
 Name:                   cab
-Version:                0.2.10
+Version:                0.2.11
 Author:                 Kazu Yamamoto <kazu@iij.ad.jp>
 Maintainer:             Kazu Yamamoto <kazu@iij.ad.jp>
 License:                BSD3
@@ -25,12 +25,11 @@ Library
                       , attoparsec >= 0.10
                       , bytestring
                       , conduit >= 1.1
-                      , conduit-extra
+                      , conduit-extra >= 1.1.2
                       , containers
                       , directory
                       , filepath
                       , process
-                      , process-conduit >= 1.1
                       , resourcet
   Exposed-Modules:	Distribution.Cab
                         Distribution.Cab.PkgDB
@@ -53,12 +52,11 @@ Executable cab
                       , attoparsec >= 0.10
                       , bytestring
                       , conduit >= 1.1
-                      , conduit-extra
+                      , conduit-extra >= 1.1.2
                       , containers
                       , directory
                       , filepath
                       , process
-                      , process-conduit >= 1.1
   Other-Modules:	Commands
                         Doc
                         Help


### PR DESCRIPTION
The [`process-conduit`](http://hackage.haskell.org/package/process-conduit-1.2.0.1) package was recently deprecated, so I replaced the usage of [`sourceCmd`](http://hackage.haskell.org/package/process-conduit-1.2.0.0/docs/Data-Conduit-ProcessOld.html#v:sourceCmd) with [`sourceCmdWithConsumer`](http://hackage.haskell.org/package/conduit-extra-1.1.2/docs/Data-Conduit-Process.html#v:sourceCmdWithConsumer) from the latest version of [`conduit-extra`](http://hackage.haskell.org/package/conduit-extra-1.1.2).
