### PR TITLE
Allow older process for compatibility

### DIFF
--- a/cab.cabal
+++ b/cab.cabal
@@ -56,7 +56,7 @@ Executable cab
                       , containers
                       , directory
                       , filepath
-                      , process >= 1.2.0.0
+                      , process
   Other-Modules:	Commands
                         Doc
                         Help

--- a/src/Run.hs
+++ b/src/Run.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE CPP #-}
 module Run (run, toSwitch) where
 
 import Data.List (intercalate)
 import Distribution.Cab
+#if MIN_VERSION_process(1,2,0)
 import System.Process (callCommand)
+#else
+import Control.Monad (void)
+import System.Cmd (system)
+#endif
 
 import Types
 
@@ -55,8 +61,14 @@ run cmdspec params opts = case routing cmdspec of
     options = optionsToString opts sws
 
 callProcess :: String -> [String] -> [Arg] -> [String] -> IO ()
-callProcess pro args0 args1 options = callCommand script
+callProcess pro args0 args1 options = systemCommand script
   where
+#if MIN_VERSION_process(1,2,0)
+    systemCommand = callCommand
+#else
+    systemCommand = void . system
+#endif
+
     script = intercalate " " $ pro : args0 ++ cat args1 ++ options
     cat [pkg,ver] = [pkg ++ "-" ++ ver]
     cat x         = x


### PR DESCRIPTION
In [two](b6f49ef153036c9ddaeeb110a8207172e28af409) previous [commits](770c071cabd3588acf937ef8f2916ad1f51a505b), I replaced a deprecated function (`system`) with a newer one (`callCommand`) which requires `process-1.2.0.0`. While this works well on GHC 7.8.3, I inadvertently made it far more difficult to install `cab` on older GHCs which are bundled with `process-1.1` or earlier.

To atone for this mistake, I went back and added CPP pragmas so that (1) earlier versions of `process` can be used, and (2) if `process-1.2` is being used, use `callCommand` instead of `system`.
