### PR TITLE
Fix for GHC 7.10

### DIFF
--- a/Distribution/Cab/GenPaths.hs
+++ b/Distribution/Cab/GenPaths.hs
@@ -50,4 +50,5 @@ getCabalFile = do
         []      -> throwIO $ userError "Cabal file does not exist"
         cfile:_ -> return cfile
   where
+    isCabal :: String -> Bool
     isCabal nm = ".cabal" `isSuffixOf` nm && length nm > 6

--- a/Distribution/Cab/PkgDB.hs
+++ b/Distribution/Cab/PkgDB.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Distribution.Cab.PkgDB (
   -- * Types
     PkgDB
@@ -30,13 +31,21 @@ import Distribution.Package (PackageName(..), PackageIdentifier(..))
 import Distribution.Simple.Compiler (PackageDB(..))
 import Distribution.Simple.GHC (configure, getInstalledPackages, getPackageDBContents)
 import Distribution.Simple.PackageIndex
-    (lookupPackageName, lookupSourcePackageId
-    , allPackages, fromList, reverseDependencyClosure
-    , topologicalOrder, PackageIndex)
+    (lookupPackageName, lookupSourcePackageId, allPackages
+    , fromList, reverseDependencyClosure, topologicalOrder)
+#if MIN_VERSION_Cabal(1,22,0)
+import Distribution.Simple.PackageIndex (InstalledPackageIndex)
+#else
+import Distribution.Simple.PackageIndex (PackageIndex)
+#endif
 import Distribution.Simple.Program.Db (defaultProgramDb)
 import Distribution.Verbosity (normal)
 
+#if MIN_VERSION_Cabal(1,22,0)
+type PkgDB = InstalledPackageIndex
+#else
 type PkgDB = PackageIndex
+#endif
 type PkgInfo = InstalledPackageInfo
 
 ----------------------------------------------------------------
@@ -63,12 +72,12 @@ toUserSpec :: Maybe FilePath -> PackageDB
 toUserSpec Nothing     = UserPackageDB
 toUserSpec (Just path) = SpecificPackageDB path
 
-getDBs :: [PackageDB] -> IO PackageIndex
+getDBs :: [PackageDB] -> IO PkgDB
 getDBs specs = do
     (_,_,pro) <- configure normal Nothing Nothing defaultProgramDb
     getInstalledPackages normal specs pro
 
-getDB :: PackageDB -> IO PackageIndex
+getDB :: PackageDB -> IO PkgDB
 getDB spec = do
     (_,_,pro) <- configure normal Nothing Nothing defaultProgramDb
     getPackageDBContents normal spec pro

--- a/cab.cabal
+++ b/cab.cabal
@@ -21,7 +21,7 @@ Library
   Default-Language:     Haskell2010
   GHC-Options:          -Wall
   Build-Depends:        base >= 4.0 && < 5
-                      , Cabal >= 1.18 && < 1.21
+                      , Cabal >= 1.18 && < 1.23
                       , attoparsec >= 0.10
                       , bytestring
                       , conduit >= 1.1

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -4,5 +4,7 @@ import Test.DocTest
 
 main :: IO ()
 main = doctest [
+    "-optP-include", "-optPdist/build/autogen/cabal_macros.h",
+
     "Distribution/Cab"
   ]


### PR DESCRIPTION
In order to make `cab` build with GHC HEAD and `Cabal-1.22`, I had to make a few minor tweaks:

* I added an explicit type signature to `isCabal` in `Distribution.Cab.GenPaths`, because otherwise, GHC 7.10 will [try to infer](https://downloads.haskell.org/~ghc/7.10.1-rc1/docs/html/users_guide/release-7-10-1.html#idp5770992) that the module needs `FlexibleContexts`.
* In `Cabal-1.22`, `PackageIndex` is now polymorphic, so I used `InstalledPackageIndex` instead (which is just a type synonym for `PackageIndex InstalledPackageInfo`).

There's also the issue of `versionTags` from `Data.Version` being deprecated, but the functions to [work around that](https://git.haskell.org/ghc.git/commitdiff/5b8fa46ca37caa9ec83b217a697628135da34506) were introduced to `base` only very recently, so I'll hold off on changing that.