### PR TITLE
Only delete import-dirs, not library-dirs

### DIFF
--- a/Distribution/Cab/Commands.hs
+++ b/Distribution/Cab/Commands.hs
@@ -126,9 +126,9 @@ purge doit opts nameVer = do
 
 getDirs :: (String,String) -> [String] -> IO [FilePath]
 getDirs (name,ver) sandboxOpts = do
-    libdirs <- queryGhcPkg "library-dirs"
+    importDirs <- queryGhcPkg "import-dirs"
     haddock <- map docDir <$> queryGhcPkg "haddock-html"
-    return $ topDir $ libdirs ++ haddock
+    return $ topDir $ importDirs ++ haddock
   where
     nameVer = name ++ "-" ++ ver
     queryGhcPkg field = do


### PR DESCRIPTION
Fixes #33. An easy fix for this issue is to delete the `import-dirs`, not the `library-dirs`. According to the [GHC users' guide](https://downloads.haskell.org/~ghc/7.10.2/docs/html/users_guide/packages.html#idp10764944):

> `import-dirs`
> 
>    (string list) A list of directories containing interface files (`.hi` files) for this package.
> 
>    If the package contains profiling libraries, then the interface files for those library modules should have the suffix `.p_hi`. So the package can contain both normal and profiling versions of the same library without conflict (see also `library_dirs` below).
> 
> `library-dirs`
> 
>    (string list) A list of directories containing libraries for this package.

So it looks like `import-dirs` gives us what we want and _only_ what we want; that is, it doesn't include any other library locations (e.g., `C:\msys64\mingw64`) like `library-dirs` would. Just to confirm, I checked how [`Cabal` is implemented](https://github.com/haskell/cabal/blob/4e8733632a52d386ab4893af31d87e350a0c657c/Cabal/Distribution/Simple/Register.hs#L318), and it appears that the set of `import-dirs` is always a subset of the set of `library-dirs`, so changing `library-dirs` to `import-dirs` should be safe.