### PR TITLE
Allow building with Cabal-1.23

### DIFF
--- a/Distribution/Cab/PkgDB.hs
+++ b/Distribution/Cab/PkgDB.hs
@@ -21,12 +21,12 @@ module Distribution.Cab.PkgDB (
   , verOfPkgInfo
   ) where
 
-import Distribution.Cab.Utils (fromDotted)
+import Distribution.Cab.Utils (fromDotted, installedComponentId)
 import Distribution.Cab.Version
 import Distribution.Cab.VerDB (PkgName)
 import Distribution.Version (Version(..))
 import Distribution.InstalledPackageInfo
-    (InstalledPackageInfo_(..), InstalledPackageInfo)
+    (InstalledPackageInfo, sourcePackageId)
 import Distribution.Package (PackageName(..), PackageIdentifier(..))
 import Distribution.Simple.Compiler (PackageDB(..))
 import Distribution.Simple.GHC (configure, getInstalledPackages, getPackageDBContents)
@@ -74,8 +74,8 @@ toUserSpec (Just path) = SpecificPackageDB path
 
 getDBs :: [PackageDB] -> IO PkgDB
 getDBs specs = do
-    (_,_,pro) <- configure normal Nothing Nothing defaultProgramDb
-    getInstalledPackages normal specs pro
+    (comp,_,pro) <- configure normal Nothing Nothing defaultProgramDb
+    getInstalledPackages normal comp specs pro
 
 getDB :: PackageDB -> IO PkgDB
 getDB spec = do
@@ -132,5 +132,5 @@ verOfPkgInfo = version . pkgVersion . sourcePackageId
 topSortedPkgs :: PkgInfo -> PkgDB -> [PkgInfo]
 topSortedPkgs pkgi db = topSort $ pkgids [pkgi]
   where
-    pkgids = map installedPackageId
+    pkgids = map installedComponentId
     topSort = topologicalOrder . fromList . reverseDependencyClosure db

--- a/Distribution/Cab/PkgDB.hs
+++ b/Distribution/Cab/PkgDB.hs
@@ -74,8 +74,12 @@ toUserSpec (Just path) = SpecificPackageDB path
 
 getDBs :: [PackageDB] -> IO PkgDB
 getDBs specs = do
-    (comp,_,pro) <- configure normal Nothing Nothing defaultProgramDb
-    getInstalledPackages normal comp specs pro
+    (_comp,_,pro) <- configure normal Nothing Nothing defaultProgramDb
+    getInstalledPackages normal
+#if MIN_VERSION_Cabal(1,23,0)
+                         comp
+#endif
+                         specs pro
 
 getDB :: PackageDB -> IO PkgDB
 getDB spec = do

--- a/Distribution/Cab/Utils.hs
+++ b/Distribution/Cab/Utils.hs
@@ -1,6 +1,23 @@
+{-# LANGUAGE CPP #-}
 module Distribution.Cab.Utils where
 
 import Data.List
+
+import Distribution.InstalledPackageInfo (InstalledPackageInfo)
+import Distribution.Simple.PackageIndex (PackageIndex)
+#if MIN_VERSION_Cabal(1,23,0)
+import qualified Distribution.InstalledPackageInfo as Cabal
+    (installedComponentId)
+import Distribution.Package (ComponentId)
+import qualified Distribution.Simple.PackageIndex as Cabal
+    (lookupComponentId)
+#else
+import qualified Distribution.InstalledPackageInfo as Cabal
+    (installedPackageId)
+import Distribution.Package (InstalledPackageId)
+import qualified Distribution.Simple.PackageIndex as Cabal
+    (lookupInstalledPackageId)
+#endif
 
 -- |
 -- >>> fromDotted "1.2.3"
@@ -16,3 +33,19 @@ fromDotted xs = case break (=='.') xs of
 -- "1.2.3"
 toDotted :: [Int] -> String
 toDotted = intercalate "." . map show
+
+#if MIN_VERSION_Cabal(1,23,0)
+installedComponentId :: InstalledPackageInfo -> ComponentId
+installedComponentId = Cabal.installedComponentId
+#else
+installedComponentId :: InstalledPackageInfo -> InstalledPackageId
+installedComponentId = Cabal.installedPackageId
+#endif
+
+#if MIN_VERSION_Cabal(1,23,0)
+lookupComponentId :: PackageIndex a -> ComponentId -> Maybe a
+lookupComponentId = Cabal.lookupComponentId
+#else
+lookupComponentId :: PackageIndex a -> InstalledPackageId -> Maybe a
+lookupComponentId = Cabal.lookupInstalledPackageId
+#endif

--- a/Distribution/Cab/Utils.hs
+++ b/Distribution/Cab/Utils.hs
@@ -52,6 +52,6 @@ lookupComponentId = Cabal.lookupComponentId
 lookupComponentId :: PackageInstalled a => PackageIndex a -> InstalledPackageId -> Maybe a
 lookupComponentId = Cabal.lookupInstalledPackageId
 #else
-lookupComponentId :: PackageIndex -> InstalledPackageId
+lookupComponentId :: PackageIndex -> InstalledPackageId -> Maybe InstalledPackageInfo
 lookupComponentId = Cabal.lookupInstalledPackageId
 #endif

--- a/Distribution/Cab/Utils.hs
+++ b/Distribution/Cab/Utils.hs
@@ -15,6 +15,7 @@ import qualified Distribution.Simple.PackageIndex as Cabal
 import qualified Distribution.InstalledPackageInfo as Cabal
     (installedPackageId)
 import Distribution.Package (InstalledPackageId)
+import Distribution.Package (PackageInstalled)
 import qualified Distribution.Simple.PackageIndex as Cabal
     (lookupInstalledPackageId)
 #endif
@@ -46,6 +47,6 @@ installedComponentId = Cabal.installedPackageId
 lookupComponentId :: PackageIndex a -> ComponentId -> Maybe a
 lookupComponentId = Cabal.lookupComponentId
 #else
-lookupComponentId :: PackageIndex a -> InstalledPackageId -> Maybe a
+lookupComponentId :: PackageInstalled a => PackageIndex a -> InstalledPackageId -> Maybe a
 lookupComponentId = Cabal.lookupInstalledPackageId
 #endif

--- a/Distribution/Cab/Utils.hs
+++ b/Distribution/Cab/Utils.hs
@@ -4,6 +4,9 @@ module Distribution.Cab.Utils where
 import Data.List
 
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
+#if MIN_VERSION_Cabal(1,21,0) && !(MIN_VERSION_Cabal(1,23,0))
+import Distribution.Package (PackageInstalled)
+#endif
 import Distribution.Simple.PackageIndex (PackageIndex)
 #if MIN_VERSION_Cabal(1,23,0)
 import qualified Distribution.InstalledPackageInfo as Cabal
@@ -15,7 +18,6 @@ import qualified Distribution.Simple.PackageIndex as Cabal
 import qualified Distribution.InstalledPackageInfo as Cabal
     (installedPackageId)
 import Distribution.Package (InstalledPackageId)
-import Distribution.Package (PackageInstalled)
 import qualified Distribution.Simple.PackageIndex as Cabal
     (lookupInstalledPackageId)
 #endif
@@ -46,7 +48,10 @@ installedComponentId = Cabal.installedPackageId
 #if MIN_VERSION_Cabal(1,23,0)
 lookupComponentId :: PackageIndex a -> ComponentId -> Maybe a
 lookupComponentId = Cabal.lookupComponentId
-#else
+#elif MIN_VERSION_Cabal(1,21,0)
 lookupComponentId :: PackageInstalled a => PackageIndex a -> InstalledPackageId -> Maybe a
+lookupComponentId = Cabal.lookupInstalledPackageId
+#else
+lookupComponentId :: PackageIndex -> InstalledPackageId
 lookupComponentId = Cabal.lookupInstalledPackageId
 #endif

--- a/cab.cabal
+++ b/cab.cabal
@@ -21,7 +21,7 @@ Library
   Default-Language:     Haskell2010
   GHC-Options:          -Wall
   Build-Depends:        base >= 4.0 && < 5
-                      , Cabal >= 1.18 && < 1.23
+                      , Cabal >= 1.18 && < 1.25
                       , attoparsec >= 0.10
                       , bytestring
                       , conduit >= 1.1


### PR DESCRIPTION
GHC 8.0.1-rc1 is out, and I needed to make some fixes related to `Cabal-1.23`-specific changes in order to make `cab` build successfully.