### PR TITLE
Update to latest Cabal changes

### DIFF
--- a/Distribution/Cab/PkgDB.hs
+++ b/Distribution/Cab/PkgDB.hs
@@ -21,7 +21,7 @@ module Distribution.Cab.PkgDB (
   , verOfPkgInfo
   ) where
 
-import Distribution.Cab.Utils (fromDotted, installedComponentId)
+import Distribution.Cab.Utils (fromDotted, installedUnitId)
 import Distribution.Cab.Version
 import Distribution.Cab.VerDB (PkgName)
 import Distribution.Version (Version(..))
@@ -77,7 +77,7 @@ getDBs specs = do
     (_comp,_,pro) <- configure normal Nothing Nothing defaultProgramDb
     getInstalledPackages normal
 #if MIN_VERSION_Cabal(1,23,0)
-                         comp
+                         _comp
 #endif
                          specs pro
 
@@ -134,7 +134,7 @@ verOfPkgInfo = version . pkgVersion . sourcePackageId
 ----------------------------------------------------------------
 
 topSortedPkgs :: PkgInfo -> PkgDB -> [PkgInfo]
-topSortedPkgs pkgi db = topSort $ pkgids [pkgi]
+topSortedPkgs pkgi db = topSort $ unitids [pkgi]
   where
-    pkgids = map installedComponentId
+    unitids = map installedUnitId
     topSort = topologicalOrder . fromList . reverseDependencyClosure db

--- a/Distribution/Cab/Utils.hs
+++ b/Distribution/Cab/Utils.hs
@@ -10,14 +10,14 @@ import Distribution.Package (PackageInstalled)
 import Distribution.Simple.PackageIndex (PackageIndex)
 #if MIN_VERSION_Cabal(1,23,0)
 import qualified Distribution.InstalledPackageInfo as Cabal
-    (installedComponentId)
-import Distribution.Package (ComponentId)
+    (installedUnitId)
+import qualified Distribution.Package as Cabal (UnitId)
 import qualified Distribution.Simple.PackageIndex as Cabal
-    (lookupComponentId)
+    (lookupUnitId)
 #else
 import qualified Distribution.InstalledPackageInfo as Cabal
     (installedPackageId)
-import Distribution.Package (InstalledPackageId)
+import qualified Distribution.Package as Cabal (InstalledPackageId)
 import qualified Distribution.Simple.PackageIndex as Cabal
     (lookupInstalledPackageId)
 #endif
@@ -38,20 +38,25 @@ toDotted :: [Int] -> String
 toDotted = intercalate "." . map show
 
 #if MIN_VERSION_Cabal(1,23,0)
-installedComponentId :: InstalledPackageInfo -> ComponentId
-installedComponentId = Cabal.installedComponentId
+type UnitId = Cabal.UnitId
 #else
-installedComponentId :: InstalledPackageInfo -> InstalledPackageId
-installedComponentId = Cabal.installedPackageId
+type UnitId = Cabal.InstalledPackageId
+#endif
+
+installedUnitId :: InstalledPackageInfo -> UnitId
+#if MIN_VERSION_Cabal(1,23,0)
+installedUnitId = Cabal.installedUnitId
+#else
+installedUnitId = Cabal.installedPackageId
 #endif
 
 #if MIN_VERSION_Cabal(1,23,0)
-lookupComponentId :: PackageIndex a -> ComponentId -> Maybe a
-lookupComponentId = Cabal.lookupComponentId
+lookupUnitId :: PackageIndex a -> UnitId -> Maybe a
+lookupUnitId = Cabal.lookupUnitId
 #elif MIN_VERSION_Cabal(1,21,0)
-lookupComponentId :: PackageInstalled a => PackageIndex a -> InstalledPackageId -> Maybe a
-lookupComponentId = Cabal.lookupInstalledPackageId
+lookupUnitId :: PackageInstalled a => PackageIndex a -> UnitId -> Maybe a
+lookupUnitId = Cabal.lookupInstalledPackageId
 #else
-lookupComponentId :: PackageIndex -> InstalledPackageId -> Maybe InstalledPackageInfo
-lookupComponentId = Cabal.lookupInstalledPackageId
+lookupUnitId :: PackageIndex -> UnitId -> Maybe InstalledPackageInfo
+lookupUnitId = Cabal.lookupInstalledPackageId
 #endif


### PR DESCRIPTION
`Cabal-1.23` changed `InstalledPackageId`'s name to `UnitId`, so update `cab` accordingly.

Also, now that [`resourcet-1.1.7.2`](http://hackage.haskell.org/package/resourcet-1.1.7.2) is on Hackage, this (and all of its dependencies) build without issue on GHC 8.0!