### PR TITLE
Allow building with Cabal-2.0

### DIFF
--- a/Distribution/Cab/GenPaths.hs
+++ b/Distribution/Cab/GenPaths.hs
@@ -6,9 +6,9 @@ import Control.Applicative
 import Control.Exception
 import Control.Monad
 import Data.List (isSuffixOf)
-import Distribution.Package
+import Distribution.Cab.Utils (readGenericPackageDescription, unPackageName)
+import Distribution.Package (pkgName, pkgVersion)
 import Distribution.PackageDescription
-import Distribution.PackageDescription.Parse (readPackageDescription)
 import Distribution.Verbosity (silent)
 import Distribution.Version
 import System.Directory
@@ -31,9 +31,9 @@ genPaths = do
 
 getNameVersion :: FilePath -> IO (String,Version)
 getNameVersion file = do
-    desc <- readPackageDescription silent file
+    desc <- readGenericPackageDescription silent file
     let pkg = package . packageDescription $ desc
-        PackageName nm = pkgName pkg
+        nm = unPackageName $ pkgName pkg
         name = map (trans '-' '_') nm
         version = pkgVersion pkg
     return (name, version)

--- a/Distribution/Cab/Utils.hs
+++ b/Distribution/Cab/Utils.hs
@@ -4,10 +4,15 @@ module Distribution.Cab.Utils where
 import Data.List
 
 import Distribution.InstalledPackageInfo (InstalledPackageInfo)
+import Distribution.Package (PackageName)
+import Distribution.PackageDescription (GenericPackageDescription)
+import Distribution.Simple.PackageIndex (PackageIndex)
+import Distribution.Verbosity (Verbosity)
+
 #if MIN_VERSION_Cabal(1,21,0) && !(MIN_VERSION_Cabal(1,23,0))
 import Distribution.Package (PackageInstalled)
 #endif
-import Distribution.Simple.PackageIndex (PackageIndex)
+
 #if MIN_VERSION_Cabal(1,23,0)
 import qualified Distribution.InstalledPackageInfo as Cabal
     (installedUnitId)
@@ -20,6 +25,17 @@ import qualified Distribution.InstalledPackageInfo as Cabal
 import qualified Distribution.Package as Cabal (InstalledPackageId)
 import qualified Distribution.Simple.PackageIndex as Cabal
     (lookupInstalledPackageId)
+#endif
+
+#if MIN_VERSION_Cabal(2,0,0)
+import qualified Distribution.Package as Cabal
+    (mkPackageName, unPackageName)
+import qualified Distribution.PackageDescription.Parse as Cabal
+    (readGenericPackageDescription)
+#else
+import qualified Distribution.Package as Cabal (PackageName(..))
+import qualified Distribution.PackageDescription.Parse as Cabal
+    (readPackageDescription)
 #endif
 
 -- |
@@ -36,6 +52,8 @@ fromDotted xs = case break (=='.') xs of
 -- "1.2.3"
 toDotted :: [Int] -> String
 toDotted = intercalate "." . map show
+
+-- UnitIds
 
 #if MIN_VERSION_Cabal(1,23,0)
 type UnitId = Cabal.UnitId
@@ -59,4 +77,29 @@ lookupUnitId = Cabal.lookupInstalledPackageId
 #else
 lookupUnitId :: PackageIndex -> UnitId -> Maybe InstalledPackageInfo
 lookupUnitId = Cabal.lookupInstalledPackageId
+#endif
+
+-- PackageNames
+
+mkPackageName :: String -> PackageName
+#if MIN_VERSION_Cabal(2,0,0)
+mkPackageName = Cabal.mkPackageName
+#else
+mkPackageName = Cabal.PackageName
+#endif
+
+unPackageName :: PackageName -> String
+#if MIN_VERSION_Cabal(2,0,0)
+unPackageName = Cabal.unPackageName
+#else
+unPackageName (Cabal.PackageName s) = s
+#endif
+
+-- GenericPackageDescription
+
+readGenericPackageDescription :: Verbosity -> FilePath -> IO GenericPackageDescription
+#if MIN_VERSION_Cabal(2,0,0)
+readGenericPackageDescription = Cabal.readGenericPackageDescription
+#else
+readGenericPackageDescription = Cabal.readPackageDescription
 #endif

--- a/Distribution/Cab/Version.hs
+++ b/Distribution/Cab/Version.hs
@@ -1,13 +1,15 @@
+{-# LANGUAGE CPP #-}
 module Distribution.Cab.Version (
     Ver
   , toVer
+  , toVersion
   , verToString
   , version
   , versionToString
   ) where
 
 import Distribution.Cab.Utils
-import Distribution.Version (Version(..))
+import Distribution.Version
 
 -- | Package version.
 newtype Ver = Ver [Int] deriving (Eq,Ord,Read,Show)
@@ -19,6 +21,14 @@ newtype Ver = Ver [Int] deriving (Eq,Ord,Read,Show)
 toVer :: [Int] -> Ver
 toVer is = Ver is
 
+-- | Creating 'Version' in Cabal.
+toVersion :: [Int] -> Version
+#if MIN_VERSION_Cabal(2,0,0)
+toVersion is = mkVersion is
+#else
+toVersion is = Version is []
+#endif
+
 -- | From 'Version' to 'String'
 --
 -- >>> verToString $ toVer [1,2,3]
@@ -28,16 +38,18 @@ verToString (Ver ver) = toDotted ver
 
 -- | From 'Version' in Cabal to 'Ver'.
 --
--- >>> version $ Version [1,2,3] []
+-- >>> version $ toVersion [1,2,3]
 -- Ver [1,2,3]
 version :: Version -> Ver
+#if MIN_VERSION_Cabal(2,0,0)
+version = Ver . versionNumbers
+#else
 version = Ver . versionBranch
+#endif
 
 -- | From 'Version' in Cabal to 'String'.
 --
--- >>> versionToString $ Version [1,2,3] []
+-- >>> versionToString $ toVersion [1,2,3]
 -- "1.2.3"
 versionToString :: Version -> String
 versionToString = verToString . version
-
-

--- a/cab.cabal
+++ b/cab.cabal
@@ -21,7 +21,7 @@ Library
   Default-Language:     Haskell2010
   GHC-Options:          -Wall
   Build-Depends:        base >= 4.0 && < 5
-                      , Cabal >= 1.18 && < 1.25
+                      , Cabal >= 1.18 && < 2.1
                       , attoparsec >= 0.10
                       , bytestring
                       , conduit >= 1.1


### PR DESCRIPTION
(`Cabal-2.0` is bundled with GHC 8.2.)

Most of the changes revolve around the fact that `Cabal-2.0` no longer exports the `Version` and `PackageName` constructors, so I needed to define some compatibility functions to avoid excessive amount of CPP.