### PR TITLE
Allow building with Cabal-2.2

### DIFF
--- a/Distribution/Cab/Printer.hs
+++ b/Distribution/Cab/Printer.hs
@@ -17,6 +17,10 @@ import Distribution.InstalledPackageInfo (author, depends, license)
 import Distribution.License (License(..))
 import Distribution.Simple.PackageIndex (allPackages)
 
+#if MIN_VERSION_Cabal(2,2,0)
+import Distribution.License (licenseFromSPDX)
+#endif
+
 ----------------------------------------------------------------
 
 type RevDB = Map UnitId [UnitId]
@@ -80,8 +84,15 @@ extraInfo :: Bool -> PkgInfo -> IO ()
 extraInfo False _ = return ()
 extraInfo True pkgi = putStr $ " " ++ lcns ++ " \"" ++  auth ++ "\""
   where
-    lcns = showLicense (license pkgi)
+    lcns = showLicense (pkgInfoLicense pkgi)
     auth = author pkgi
+
+pkgInfoLicense :: PkgInfo -> License
+#if MIN_VERSION_Cabal(2,2,0)
+pkgInfoLicense = either licenseFromSPDX id . license
+#else
+pkgInfoLicense = license
+#endif
 
 showLicense :: License -> String
 showLicense (GPL (Just v))     = "GPL" ++ versionToString v

--- a/Distribution/Cab/Utils.hs
+++ b/Distribution/Cab/Utils.hs
@@ -30,10 +30,17 @@ import qualified Distribution.Simple.PackageIndex as Cabal
 #if MIN_VERSION_Cabal(2,0,0)
 import qualified Distribution.Package as Cabal
     (mkPackageName, unPackageName)
+#else
+import qualified Distribution.Package as Cabal (PackageName(..))
+#endif
+
+#if MIN_VERSION_Cabal(2,2,0)
+import qualified Distribution.PackageDescription.Parsec as Cabal
+    (readGenericPackageDescription)
+#elif MIN_VERSION_Cabal(2,0,0)
 import qualified Distribution.PackageDescription.Parse as Cabal
     (readGenericPackageDescription)
 #else
-import qualified Distribution.Package as Cabal (PackageName(..))
 import qualified Distribution.PackageDescription.Parse as Cabal
     (readPackageDescription)
 #endif


### PR DESCRIPTION
A couple of small tweaks are needed to make `cab` build with `Cabal-2.2` (shipped with GHC 8.4.1):

* The `readGenericPackageDescription` function now lives in `Distribution.PackageDescription.Parsec`.
* `license` now returns `Either SPXLicense License` instead of just `License`, so we must do a little bit of extra work to turn that into a `license`.